### PR TITLE
feat(workflow): 노드 속성 편집 및 연결 관리 기능 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,9 +6,7 @@ function App() {
   return (
     <div className="flex h-screen">
       <Sidebar />
-      <div className="flex-1">
-        <MLWorkflow />
-      </div>
+      <MLWorkflow />
     </div>
   );
 }

--- a/src/components/AttributePanel.js
+++ b/src/components/AttributePanel.js
@@ -1,0 +1,144 @@
+import React, { useState } from 'react';
+
+const inputClass = "w-full px-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500";
+const labelClass = "block text-sm font-medium text-gray-600 mb-1";
+
+// DataInput 노드 전용 속성 컴포넌트
+const DataInputAttributes = ({ data, onDataChange }) => {
+  const [connectionStatus, setConnectionStatus] = useState({ state: 'idle', message: '' });
+  const handleInputChange = (e) => onDataChange({ [e.target.name]: e.target.value });
+  const handleFileChange = (e) => {
+    if (e.target.files && e.target.files[0]) {
+      onDataChange({ uploadedFileName: e.target.files[0].name });
+    }
+  };
+  const handleTestConnection = async () => {
+    setConnectionStatus({ state: 'loading', message: 'Connecting...' });
+    // This is a mock API call. You would need a real backend for this to work.
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    setConnectionStatus({ state: 'success', message: 'Connection successful! (Mock)' });
+  };
+
+  return (
+    <div>
+      <label className={labelClass}>Data Source Type</label>
+      <div className="flex items-center space-x-4 mb-4">
+        {['filePath', 'fileUpload', 'dbConnection'].map(type => (
+          <label key={type} className="flex items-center text-sm">
+            <input
+              type="radio" name="sourceType" value={type} checked={data.sourceType === type} onChange={handleInputChange}
+              className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500" />
+            <span className="ml-2 capitalize">{type.replace(/([A-Z])/g, ' $1')}</span>
+          </label>
+        ))}
+      </div>
+      {data.sourceType === 'filePath' && (
+        <div>
+          <label htmlFor="filePath" className={labelClass}>File Path</label>
+          <input id="filePath" name="filePath" type="text" value={data.filePath || ''} onChange={handleInputChange} className={inputClass} />
+        </div>
+      )}
+      {data.sourceType === 'fileUpload' && (
+        <div>
+          <label htmlFor="fileUpload" className={labelClass}>Upload File (.csv, .xlsx)</label>
+          <input id="fileUpload" name="fileUpload" type="file" accept=".csv, .xlsx, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel" onChange={handleFileChange} className={`${inputClass} p-0 file:mr-4 file:py-2 file:px-4 file:rounded-l-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100`} />
+          {data.uploadedFileName && <p className="text-xs text-gray-500 mt-2">Selected: {data.uploadedFileName}</p>}
+        </div>
+      )}
+      {data.sourceType === 'dbConnection' && (
+        <div className="space-y-4 p-3 bg-gray-100 rounded-md">
+            <div>
+              <label htmlFor="dbType" className={labelClass}>Database Type</label>
+              <select id="dbType" name="dbType" value={data.dbType} onChange={handleInputChange} className={inputClass}>
+                <option>PostgreSQL</option><option>MySQL</option><option>MSSQL</option><option>SQLite</option>
+              </select>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <div><label htmlFor="dbHost" className={labelClass}>Host</label><input id="dbHost" name="dbHost" type="text" value={data.dbHost} onChange={handleInputChange} className={inputClass}/></div>
+                <div><label htmlFor="dbPort" className={labelClass}>Port</label><input id="dbPort" name="dbPort" type="text" value={data.dbPort} onChange={handleInputChange} className={inputClass}/></div>
+            </div>
+            <div><label htmlFor="dbName" className={labelClass}>Database</label><input id="dbName" name="dbName" type="text" value={data.dbName} onChange={handleInputChange} className={inputClass}/></div>
+            <div><label htmlFor="dbUser" className={labelClass}>User</label><input id="dbUser" name="dbUser" type="text" value={data.dbUser} onChange={handleInputChange} className={inputClass}/></div>
+            <div><label htmlFor="dbPassword" className={labelClass}>Password</label><input id="dbPassword" name="dbPassword" type="password" value={data.dbPassword} onChange={handleInputChange} className={inputClass}/></div>
+            <div className="mt-4">
+              <button onClick={handleTestConnection} disabled={connectionStatus.state === 'loading'} className="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:bg-gray-400">
+                {connectionStatus.state === 'loading' ? 'Testing...' : 'Test Connection'}
+              </button>
+              {connectionStatus.state !== 'idle' && (
+                <p className={`mt-2 text-xs ${connectionStatus.state === 'success' ? 'text-green-600' : connectionStatus.state === 'error' ? 'text-red-600' : 'text-gray-500'}`}>{connectionStatus.message}</p>
+              )}
+            </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// 메인 속성 패널 컴포넌트
+export default function AttributePanel({ selectedNode, selectedEdge, onNodeDataChange, onEdgeDelete }) {
+  const handleInputChange = (event) => {
+    onNodeDataChange(selectedNode.id, { [event.target.name]: event.target.value });
+  };
+
+  // --- 추가된 부분: 엣지 선택 시 UI 렌더링 ---
+  if (selectedEdge) {
+    return (
+      <aside className="w-80 bg-gray-50 p-6 border-l border-gray-200">
+        <h3 className="text-lg font-semibold text-gray-700 mb-4">Connection Details</h3>
+        <div className="space-y-4">
+          <div className="text-sm bg-white p-3 rounded-md border border-gray-200">
+            <p className="text-gray-500">From Node: <strong className="text-gray-800">{selectedEdge.source}</strong></p>
+            <p className="text-gray-500">To Node: <strong className="text-gray-800">{selectedEdge.target}</strong></p>
+          </div>
+          <button
+            onClick={onEdgeDelete}
+            className="w-full flex items-center justify-center bg-red-600 text-white py-2 px-4 rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+            Delete Connection
+          </button>
+          <p className="text-xs text-center text-gray-500">Or select the connection and press 'Delete' or 'Backspace'.</p>
+        </div>
+      </aside>
+    );
+  }
+  // --- 여기까지 ---
+  
+  // --- 아래는 기존 노드 선택 시 UI 로직 ---
+  const renderNodeSpecificAttributes = () => {
+    if (!selectedNode) return null;
+    const { type, data } = selectedNode;
+    if (type === 'dataInput') return <DataInputAttributes data={data} onDataChange={(newData) => onNodeDataChange(selectedNode.id, newData)} />;
+    
+    switch (type) {
+      case 'preprocessing': return (<div><label htmlFor="method" className={labelClass}>Method</label><select id="method" name="method" value={data.method || 'StandardScaler'} onChange={handleInputChange} className={inputClass}><option>StandardScaler</option><option>MinMaxScaler</option><option>RobustScaler</option><option>OneHotEncoder</option></select></div>);
+      case 'model': return (<><div><label htmlFor="algorithm" className={labelClass}>Algorithm</label><select id="algorithm" name="algorithm" value={data.algorithm || 'LogisticRegression'} onChange={handleInputChange} className={inputClass}><option>LogisticRegression</option><option>SVM</option><option>DecisionTree</option><option>RandomForest</option></select></div><div className="mt-4"><label htmlFor="hyperparameters" className={labelClass}>Hyperparameters (JSON)</label><textarea id="hyperparameters" name="hyperparameters" value={data.hyperparameters || ''} onChange={handleInputChange} className={`${inputClass} font-mono`} rows="4"/></div></>);
+      case 'evaluation': return (<div><label htmlFor="metric" className={labelClass}>Metric</label><select id="metric" name="metric" value={data.metric || 'Accuracy'} onChange={handleInputChange} className={inputClass}><option>Accuracy</option><option>Precision</option><option>Recall</option><option>F1-score</option><option>MSE</option><option>MAE</option></select></div>);
+      default: return <p className="text-sm text-gray-500">No specific attributes for this node type.</p>;
+    }
+  };
+
+  if (selectedNode) {
+    return (
+      <aside className="w-80 bg-gray-50 p-6 border-l border-gray-200 overflow-y-auto">
+        <h3 className="text-lg font-semibold text-gray-700 mb-4">Edit: {selectedNode.data.label}</h3>
+        <div className="space-y-4">
+          <div><label htmlFor="label" className={labelClass}>Label</label><input id="label" name="label" type="text" value={selectedNode.data.label} onChange={handleInputChange} className={inputClass}/></div>
+          <div><label htmlFor="description" className={labelClass}>Description</label><textarea id="description" name="description" value={selectedNode.data.description} onChange={handleInputChange} className={inputClass} rows="3"/></div>
+          <hr className="my-4"/>
+          <h4 className="text-md font-semibold text-gray-700 mt-4">Type Specific Attributes</h4>
+          {renderNodeSpecificAttributes()}
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="w-80 bg-gray-50 p-6 border-l border-gray-200">
+      <h3 className="text-lg font-semibold text-gray-700">Attributes</h3>
+      <p className="mt-2 text-sm text-gray-500">Select a node or connection to view and edit its attributes.</p>
+    </aside>
+  );
+}

--- a/src/components/MLWorkflow.js
+++ b/src/components/MLWorkflow.js
@@ -8,12 +8,14 @@ import ReactFlow, {
   addEdge,
   useReactFlow,
   ReactFlowProvider,
+  MarkerType,
 } from 'reactflow';
 
 import DataInputNode from './nodes/DataInputNode';
 import PreprocessingNode from './nodes/PreprocessingNode';
 import ModelNode from './nodes/ModelNode';
 import EvaluationNode from './nodes/EvaluationNode';
+import AttributePanel from './AttributePanel';
 
 import 'reactflow/dist/style.css';
 
@@ -24,13 +26,30 @@ const nodeTypes = {
   evaluation: EvaluationNode,
 };
 
+const defaultEdgeOptions = {
+  style: { strokeWidth: 2, stroke: '#a1a1aa' },
+  markerEnd: {
+    type: MarkerType.ArrowClosed,
+    color: '#a1a1aa',
+  },
+};
+
 const initialNodes = [
   {
     id: '1',
     type: 'dataInput',
-    data: { 
+    data: {
       label: 'Data Input',
-      description: 'Load dataset'
+      description: 'Load dataset',
+      sourceType: 'filePath',
+      filePath: '/path/to/data.csv',
+      uploadedFileName: null,
+      dbType: 'PostgreSQL',
+      dbHost: 'localhost',
+      dbPort: '5432',
+      dbUser: 'admin',
+      dbPassword: '',
+      dbName: 'mydatabase',
     },
     position: { x: 100, y: 100 },
   },
@@ -38,31 +57,43 @@ const initialNodes = [
 
 const initialEdges = [];
 
-// 노드 타입별 기본 데이터 정의
 const getNodeData = (nodeType) => {
   const nodeDataMap = {
     dataInput: {
       label: 'Data Input',
-      description: 'Load dataset'
+      description: 'Load dataset',
+      sourceType: 'filePath',
+      filePath: '/path/to/data.csv',
+      uploadedFileName: null,
+      dbType: 'PostgreSQL',
+      dbHost: 'localhost',
+      dbPort: '5432',
+      dbUser: 'admin',
+      dbPassword: '',
+      dbName: 'mydatabase',
     },
     preprocessing: {
-      label: 'Data Preprocessing', 
-      description: 'Clean and transform data'
+      label: 'Data Preprocessing',
+      description: 'Clean and transform data',
+      method: 'StandardScaler',
     },
     model: {
       label: 'ML Model',
-      description: 'Train machine learning model'
+      description: 'Train machine learning model',
+      algorithm: 'LogisticRegression',
+      hyperparameters: '{ "C": 1.0 }',
     },
     evaluation: {
       label: 'Model Evaluation',
-      description: 'Evaluate model performance'
+      description: 'Evaluate model performance',
+      metric: 'Accuracy',
     }
   };
-  
+
   return nodeDataMap[nodeType] || { label: 'Unknown', description: '' };
 };
 
-let id = 0;
+let id = 2;
 const getId = () => `dndnode_${id++}`;
 
 function MLWorkflowCanvas() {
@@ -70,6 +101,8 @@ function MLWorkflowCanvas() {
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const [reactFlowInstance, setReactFlowInstance] = useState(null);
+  const [selectedNode, setSelectedNode] = useState(null);
+  const [selectedEdge, setSelectedEdge] = useState(null); // 선택된 엣지 상태 추가
   const { screenToFlowPosition } = useReactFlow();
 
   const onConnect = useCallback(
@@ -80,77 +113,108 @@ function MLWorkflowCanvas() {
   const onDragOver = useCallback((event) => {
     event.preventDefault();
     event.dataTransfer.dropEffect = 'move';
-    console.log('Drag over detected'); // 디버깅용
   }, []);
 
   const onDrop = useCallback(
     (event) => {
       event.preventDefault();
-      console.log('Drop event triggered'); // 디버깅용
-
-      const reactFlowBounds = reactFlowWrapper.current.getBoundingClientRect();
       const type = event.dataTransfer.getData('application/reactflow');
+      if (typeof type === 'undefined' || !type) return;
       
-      console.log('Dropped node type:', type); // 디버깅용
-
-      // 유효하지 않은 타입이면 리턴
-      if (typeof type === 'undefined' || !type) {
-        console.log('Invalid node type'); // 디버깅용
-        return;
-      }
-
       const position = screenToFlowPosition({
-        x: event.clientX - reactFlowBounds.left,
-        y: event.clientY - reactFlowBounds.top,
+        x: event.clientX,
+        y: event.clientY,
       });
-
-      console.log('New node position:', position); // 디버깅용
-
       const newNode = {
         id: getId(),
         type,
         position,
         data: getNodeData(type),
       };
-
-      console.log('Creating new node:', newNode); // 디버깅용
       setNodes((nds) => nds.concat(newNode));
     },
-    [reactFlowInstance, screenToFlowPosition, setNodes]
+    [screenToFlowPosition, setNodes]
   );
-
-  const onInit = useCallback((reactFlowInstance) => {
-    console.log('ReactFlow initialized'); // 디버깅용
-    setReactFlowInstance(reactFlowInstance);
+  
+  // --- 수정된 핸들러 ---
+  const onNodeClick = useCallback((event, node) => {
+    setSelectedNode(node);
+    setSelectedEdge(null); // 노드 클릭 시 엣지 선택 해제
   }, []);
 
+  const onEdgeClick = useCallback((event, edge) => {
+    setSelectedEdge(edge);
+    setSelectedNode(null); // 엣지 클릭 시 노드 선택 해제
+  }, []);
+
+  const onPaneClick = useCallback(() => {
+    setSelectedNode(null);
+    setSelectedEdge(null);
+  }, []);
+  
+  // --- 에러 해결: 'removeEdges' 대신 filter 사용 ---
+  const deleteSelectedEdge = useCallback(() => {
+    if (selectedEdge) {
+      setEdges((eds) => eds.filter((edge) => edge.id !== selectedEdge.id));
+      setSelectedEdge(null);
+    }
+  }, [selectedEdge, setEdges]);
+  // --- 여기까지 ---
+
+  const onNodeDataChange = (nodeId, newData) => {
+    setNodes((nds) =>
+      nds.map((node) => {
+        if (node.id === nodeId) {
+          return { ...node, data: { ...node.data, ...newData } };
+        }
+        return node;
+      })
+    );
+    if (selectedNode && selectedNode.id === nodeId) {
+        setSelectedNode((prevNode) => ({
+            ...prevNode,
+            data: {
+            ...prevNode.data,
+            ...newData,
+            },
+        }));
+    }
+  };
+
   return (
-    <div 
-      className="flex-1" 
-      ref={reactFlowWrapper}
-      style={{ width: '100%', height: '100vh' }}
-    >
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        onConnect={onConnect}
-        onInit={onInit}
-        onDrop={onDrop}
-        onDragOver={onDragOver}
-        nodeTypes={nodeTypes}
-        fitView
-      >
-        <Controls />
-        <MiniMap />
-        <Background variant="dots" gap={12} size={1} />
-      </ReactFlow>
+    <div className="flex flex-1 h-full">
+      <div className="flex-1" ref={reactFlowWrapper}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onInit={setReactFlowInstance}
+          onDrop={onDrop}
+          onDragOver={onDragOver}
+          onNodeClick={onNodeClick}
+          onEdgeClick={onEdgeClick} // 엣지 클릭 핸들러 추가
+          onPaneClick={onPaneClick} // 캔버스 클릭 핸들러 추가
+          nodeTypes={nodeTypes}
+          defaultEdgeOptions={defaultEdgeOptions}
+          fitView
+        >
+          <Controls />
+          <MiniMap />
+          <Background variant="dots" gap={12} size={1} />
+        </ReactFlow>
+      </div>
+      <AttributePanel
+        selectedNode={selectedNode}
+        selectedEdge={selectedEdge} // 선택된 엣지 정보 전달
+        onNodeDataChange={onNodeDataChange}
+        onEdgeDelete={deleteSelectedEdge} // 엣지 삭제 함수 전달
+      />
     </div>
   );
 }
 
-// ReactFlowProvider로 감싸서 내보내기
 export default function MLWorkflow() {
   return (
     <ReactFlowProvider>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -45,13 +45,6 @@ export default function Sidebar() {
           );
         })}
       </div>
-      
-      {/* 테스트용 버튼 */}
-      <div className="mt-4 p-2 bg-yellow-100 rounded">
-        <p className="text-xs text-gray-600">
-          드래그가 안되면 브라우저 콘솔(F12)에서 메시지를 확인하세요.
-        </p>
-      </div>
     </aside>
   );
 }

--- a/src/components/nodes/DataInputNode.js
+++ b/src/components/nodes/DataInputNode.js
@@ -1,18 +1,34 @@
 import React from 'react';
 import { Handle, Position } from 'reactflow';
-import { Database } from 'lucide-react';
+
+const getSourceIcon = (sourceType) => {
+  switch (sourceType) {
+    case 'fileUpload':
+      return '📄'; // File icon
+    case 'dbConnection':
+      return '🗄️'; // Database icon
+    case 'filePath':
+    default:
+      return '📁'; // Folder icon for file path
+  }
+};
 
 export default function DataInputNode({ data }) {
   return (
-    <div className="px-4 py-2 shadow-md rounded-md bg-blue-100 border-2 border-blue-300">
-      <div className="flex items-center">
-        <Database className="w-4 h-4 mr-2" />
-        <div className="ml-2">
-          <div className="text-lg font-bold">{data.label}</div>
-          <div className="text-gray-500">{data.description}</div>
+    <div className="w-48 shadow-lg rounded-md overflow-hidden bg-white border-2 border-indigo-500">
+      <div className="p-2 bg-indigo-500 text-white text-sm">
+        Data Input
+      </div>
+      <div className="p-3">
+        <div className="flex items-center">
+          <div className="text-3xl mr-3">{getSourceIcon(data.sourceType)}</div>
+          <div>
+            <div className="text-sm font-bold text-gray-800">{data.label}</div>
+            <p className="text-xs text-gray-500">{data.description}</p>
+          </div>
         </div>
       </div>
-      <Handle type="source" position={Position.Right} />
+      <Handle type="source" position={Position.Right} className="w-3 h-3 !bg-indigo-500" />
     </div>
   );
 }


### PR DESCRIPTION
주요 변경 사항:
- React Flow 노드 클릭 시, 우측에 속성 편집 패널이 나타나도록 구현
- 노드 타입(DataInput, Preprocessing 등)에 따른 맞춤형 속성 입력 UI 추가
- DataInput 노드에 파일 업로드 및 DB 연결 정보 입력 UI 구성
- 연결선(Edge)을 클릭하여 선택하고, 키보드(Delete) 또는 삭제 버튼으로 제거하는 기능 추가
- 연결선의 가시성 개선 (두께 및 색상, 화살표 마커 적용)